### PR TITLE
Fix data split overlap in MLModelSelector

### DIFF
--- a/streamlit_app/ml_processor.py
+++ b/streamlit_app/ml_processor.py
@@ -28,8 +28,9 @@ class MLModelSelector:
         Prepares the data by splitting it into training and testing sets based on a split date or split ratio.
         """
         if self.split_date:
-            train = self.data.loc[:self.split_date]
-            test = self.data.loc[self.split_date:]
+            split_date = pd.to_datetime(self.split_date)
+            train = self.data[self.data.index < split_date]
+            test = self.data[self.data.index >= split_date]
         else:
             split_idx = int(len(self.data) * self.split_ratio)
             train = self.data.iloc[:split_idx]

--- a/tests/test_ml_processor.py
+++ b/tests/test_ml_processor.py
@@ -1,0 +1,13 @@
+import sys, os
+import pandas as pd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'streamlit_app'))
+from ml_processor import MLModelSelector
+
+def test_prepare_data_split_date_no_overlap():
+    dates = pd.date_range('2020-01-01', periods=10, freq='D')
+    df = pd.DataFrame({'y': range(10), 'x': range(10)}, index=dates)
+    selector = MLModelSelector(df, target_column='y', hyperparameter_mode='Manual', split_date='2020-01-06')
+    assert selector.X_train.index.max() < pd.Timestamp('2020-01-06')
+    assert selector.X_test.index.min() >= pd.Timestamp('2020-01-06')
+    assert len(selector.X_train) + len(selector.X_test) == len(df)


### PR DESCRIPTION
## Summary
- fix train/test split to avoid including split date in both sets
- add regression test for split-date splitting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891efa9b2748321ad1583e02171d1e4